### PR TITLE
Fix rare division by zero if p=1.0

### DIFF
--- a/covidsimulation/simulation.pyx
+++ b/covidsimulation/simulation.pyx
@@ -108,7 +108,7 @@ cpdef logit_transform_value(double p, double adjustment_logit):
 
 
 cdef sample_from_logit_uniform(double adjustment_logit):
-    cdef float p = rand() / (RAND_MAX + 1.0)
+    cdef double p = (rand() + 1.0) / (RAND_MAX + 2.0)
     return logit_transform_value(p, adjustment_logit)
 
 


### PR DESCRIPTION
Fix by not temporarily converting probability to float and avoiding p=0.0